### PR TITLE
feat: Make autorestic configuration file path configurable

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Run ansible-lint
-        uses: ansible-community/ansible-lint-action@v6
+        uses: ansible/ansible-lint@v24

--- a/.github/workflows/ansible-release.yml
+++ b/.github/workflows/ansible-release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           path: "dbrennand.autorestic"
 
@@ -22,9 +22,9 @@ jobs:
       - id: role_name
         run: echo "::set-output name=role_name::$(yq -r '.galaxy_info.role_name' meta/main.yml)"
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - run: pip3 install ansible-core
 

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -9,7 +9,7 @@ jobs:
   molecule:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           path: dbrennand.autorestic
       - uses: gofrolist/molecule-action@v2

--- a/README.md
+++ b/README.md
@@ -131,3 +131,5 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) for 
 [**PleaseStopAsking**](https://github.com/PleaseStopAsking) - *Contributor*
 
 [**markstos**](https://github.com/markstos) - *Contributor*
+
+[**micxer**](https://github.com/micxer) - *Contributor*

--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@ autorestic_config:
         B2_ACCOUNT_KEY: Key
 ```
 
-The autorestic YAML configuration to be placed into the `~/.autorestic.yml` file. See the [autorestic documentation](https://autorestic.vercel.app/config) for details on the YAML configuration.
+See the [autorestic documentation](https://autorestic.vercel.app/config) for details on the YAML configuration.
+
+```yaml
+autorestic_config_file: ~/.autorestic.yml
+```
+
+The autorestic YAML configuration to be placed into the `~/.autorestic.yml` file.
 
 ```yaml
 autorestic_info: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ autorestic_config:
       env:
         B2_ACCOUNT_ID: ID
         B2_ACCOUNT_KEY: Key
+autorestic_config_file: ~/.autorestic.yml
 autorestic_info: false
 autorestic_check: false
 autorestic_cron: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,7 +48,7 @@
 - name: Create autorestic configuration file
   ansible.builtin.copy:
     content: "{{ autorestic_config | to_yaml }}"
-    dest: ~/.autorestic.yml
+    dest: "{{ autorestic_config_file }}"
     mode: "0600"
 
 - name: Run autorestic info
@@ -79,7 +79,7 @@
         minute: "*/5"
         job: |
           {% if autorestic_cron_verbose == true %}
-          autorestic -c ~/.autorestic.yml --ci cron -vvvvv > /tmp/autorestic.log 2>&1
+          autorestic -c {{ autorestic_config_file }} --ci cron -vvvvv > /tmp/autorestic.log 2>&1
           {% else %}
-          autorestic -c ~/.autorestic.yml --ci cron > /tmp/autorestic.log 2>&1
+          autorestic -c {{ autorestic_config_file }} --ci cron > /tmp/autorestic.log 2>&1
           {% endif %}

--- a/tasks/removal.yml
+++ b/tasks/removal.yml
@@ -11,7 +11,7 @@
 
 - name: Remove autorestic configuration file
   ansible.builtin.file:
-    path: ~/.autorestic.yml
+    path: "{{ autorestic_config_file }}"
     state: absent
 
 - name: Remove restic binary
@@ -37,5 +37,5 @@
       ansible.builtin.cron:
         name: Configure autorestic crontab job
         minute: "*/5"
-        job: autorestic -c ~/.autorestic.yml --ci cron > /tmp/autorestic.log 2>&1
+        job: autorestic -c {{ autorestic_config_file }} --ci cron > /tmp/autorestic.log 2>&1
         state: absent


### PR DESCRIPTION
This commit updates the autorestic configuration file path to use the `autorestic_config_file` variable instead of hardcoding `~/.autorestic.yml`. This change allows for greater flexibility and customization in specifying the location of the configuration file.